### PR TITLE
Fix Docker build by adding Rust compilation dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,14 @@ FROM python:3.9-slim
 # Set the working directory in the container
 WORKDIR /usr/src/app
 
+# Install build dependencies for Rust compilation
+RUN apt-get update && apt-get install -y \
+    gcc \
+    g++ \
+    make \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy the current directory contents into the container
 COPY . .
 


### PR DESCRIPTION
- Add gcc, g++, make, and curl to python:3.9-slim base image
- Resolves 'linker cc not found' error during Rust bindings compilation
- Clean up apt cache to minimize image size

## Description 📝

> Please provide a larger description of what did you do in this PR

## GITHUB ISSUE 🎟️

> Please provide the ticket related to this PR, using a link
> [https://github.com/VaidhyaMegha/issues/865](Ticket#865)

## FYI 🙋

> Please tag (@) people who need to be noticed about this changes

## Screenshots 📸

> Please add a screenshot or video if it's needed to show us the changes implemented (if needed)

## Test ✍️

> Please provide instructions to run test for this new code (if needed)
